### PR TITLE
[REFACTOR] Use "rules" instead of tightly integrated validation logic

### DIFF
--- a/lib/commit-message-parser/commit-message-parser.js
+++ b/lib/commit-message-parser/commit-message-parser.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const COMMIT_TYPES = require('../commit-types').COMMIT_TYPES;
+
+// Get the commit type from a commit message, e.g. "[J#PROJ-123][BUG] Fixes some bug"
+// or "[BUG] Fixes some bug" would match "BUG".
+const COMMIT_TYPE_REGEX = new RegExp(`^(\\[.#[A-Z0-9\-]+\\])?\\[(${COMMIT_TYPES.join('|')})\\]`);
+
+// Check if a commit is a merge commit
+const MERGE_COMMIT_REGEX = new RegExp(`^Merge .+$`);
+
+module.exports = class CommitMessageParser {
+
+    /**
+     * Check if a commit message is a single line commit message (i.e. only a summary).
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {boolean}
+     */
+    static isSingleLineCommitMessage (commitMessage) {
+        return CommitMessageParser.getLines(commitMessage).length === 1;
+    }
+
+    /**
+     * @param {string} commitMessage
+     *
+     * @returns {string|undefined}
+     */
+    static getCommitType (commitMessage) {
+        const summary = CommitMessageParser.getSummary(commitMessage);
+        const matches = summary.match(COMMIT_TYPE_REGEX);
+        const commitTypeIndex = 2;
+
+        if (!matches) {
+            return undefined;
+        }
+
+        return matches[commitTypeIndex];
+    }
+
+    /**
+     * Get the first line (the summary) of a commit message.
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {string}
+     */
+    static getSummary (commitMessage) {
+        const lines = CommitMessageParser.getLines(commitMessage);
+
+        return lines[0];
+    }
+
+    /**
+     * Get the lines of a commit message, split into an array.
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {Array<string>}
+     */
+    static getLines (commitMessage) {
+        return commitMessage.split('\n');
+    }
+
+    /**
+     * Check if a commit message is a merge commit.
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {boolean}
+     */
+    static isMergeCommit (commitMessage) {
+        const summary = CommitMessageParser.getSummary(commitMessage);
+
+        return MERGE_COMMIT_REGEX.test(summary);
+    }
+};

--- a/lib/commit-message-parser/commit-message-parser.js
+++ b/lib/commit-message-parser/commit-message-parser.js
@@ -18,8 +18,8 @@ module.exports = class CommitMessageParser {
      *
      * @returns {boolean}
      */
-    static isSingleLineCommitMessage (commitMessage) {
-        return CommitMessageParser.getLines(commitMessage).length === 1;
+    isSingleLineCommitMessage (commitMessage) {
+        return this.getLines(commitMessage).length === 1;
     }
 
     /**
@@ -27,8 +27,8 @@ module.exports = class CommitMessageParser {
      *
      * @returns {string|undefined}
      */
-    static getCommitType (commitMessage) {
-        const summary = CommitMessageParser.getSummary(commitMessage);
+    getCommitType (commitMessage) {
+        const summary = this.getSummary(commitMessage);
         const matches = summary.match(COMMIT_TYPE_REGEX);
         const commitTypeIndex = 2;
 
@@ -46,8 +46,8 @@ module.exports = class CommitMessageParser {
      *
      * @returns {string}
      */
-    static getSummary (commitMessage) {
-        const lines = CommitMessageParser.getLines(commitMessage);
+    getSummary (commitMessage) {
+        const lines = this.getLines(commitMessage);
 
         return lines[0];
     }
@@ -59,7 +59,7 @@ module.exports = class CommitMessageParser {
      *
      * @returns {Array<string>}
      */
-    static getLines (commitMessage) {
+    getLines (commitMessage) {
         return commitMessage.split('\n');
     }
 
@@ -70,8 +70,8 @@ module.exports = class CommitMessageParser {
      *
      * @returns {boolean}
      */
-    static isMergeCommit (commitMessage) {
-        const summary = CommitMessageParser.getSummary(commitMessage);
+    isMergeCommit (commitMessage) {
+        const summary = this.getSummary(commitMessage);
 
         return MERGE_COMMIT_REGEX.test(summary);
     }

--- a/lib/commit-message-parser/index.js
+++ b/lib/commit-message-parser/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const CommitMessageParser = require('./commit-message-parser');
+
+module.exports = CommitMessageParser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const HasNewLineBetweenSummaryAndDescriptionRule = require('./rules/has-new-line
 
 const commitMessageParser = new CommitMessageParser();
 
-// Cofigure the rules that we'll test commit messages against
+// Configure the rules that we'll test commit messages against
 const rules = [
     new ValidSummaryRule(commitMessageParser),
     new HasValidCommitTypeRule(commitMessageParser),

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,19 @@ const childProcess = require('child_process');
 const GitHelper = require('./git-helper');
 const Validator = require('./validator');
 
+// Import rules
+const ValidSummaryRule = require('./rules/valid-summary-rule');
+const HasValidCommitTypeRule = require('./rules/has-valid-commit-type-rule');
+const HasNewLineBetweenSummaryAndDescriptionRule = require('./rules/has-new-line-between-summary-and-description-rule');
+
+// Cofigure the rules that we'll test commit messages against
+const rules = [
+    new ValidSummaryRule(),
+    new HasValidCommitTypeRule(),
+    new HasNewLineBetweenSummaryAndDescriptionRule()
+];
+
 const gitHelper = new GitHelper(childProcess.exec);
-const validator = new Validator(gitHelper);
+const validator = new Validator(gitHelper, rules);
 
 module.exports = validator;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const childProcess = require('child_process');
 
+const CommitMessageParser = require('./commit-message-parser');
 const GitHelper = require('./git-helper');
 const Validator = require('./validator');
 
@@ -10,14 +11,16 @@ const ValidSummaryRule = require('./rules/valid-summary-rule');
 const HasValidCommitTypeRule = require('./rules/has-valid-commit-type-rule');
 const HasNewLineBetweenSummaryAndDescriptionRule = require('./rules/has-new-line-between-summary-and-description-rule');
 
+const commitMessageParser = new CommitMessageParser();
+
 // Cofigure the rules that we'll test commit messages against
 const rules = [
-    new ValidSummaryRule(),
-    new HasValidCommitTypeRule(),
-    new HasNewLineBetweenSummaryAndDescriptionRule()
+    new ValidSummaryRule(commitMessageParser),
+    new HasValidCommitTypeRule(commitMessageParser),
+    new HasNewLineBetweenSummaryAndDescriptionRule(commitMessageParser)
 ];
 
 const gitHelper = new GitHelper(childProcess.exec);
-const validator = new Validator(gitHelper, rules);
+const validator = new Validator(gitHelper, commitMessageParser, rules);
 
 module.exports = validator;

--- a/lib/rules/has-new-line-between-summary-and-description-rule.js
+++ b/lib/rules/has-new-line-between-summary-and-description-rule.js
@@ -1,12 +1,24 @@
 'use strict';
 
-const CommitMessageParser = require('../commit-message-parser');
 const ValidationResult = require('../validation-result');
 
 module.exports = class HasNewLineBetweenSummaryAndDescriptionRule {
 
-    constructor () {
+    /**
+     * @param {CommitMessageParser} commitMessageParser
+     */
+    constructor (commitMessageParser) {
+
+        /**
+         * @type {string}
+         */
         this.type = 'NO_NEW_LINE_AFTER_FIRST_LINE';
+
+        /**
+         * @type {CommitMessageParser}
+         * @private
+         */
+        this._commitMessageParser = commitMessageParser;
     }
 
     /**
@@ -19,7 +31,7 @@ module.exports = class HasNewLineBetweenSummaryAndDescriptionRule {
     validate (commitMessage) {
         // For single-line commit messages, just consider them valid as testing for a new-line after the summary
         // just doesn't make any sense.
-        if (CommitMessageParser.isSingleLineCommitMessage(commitMessage)) {
+        if (this._commitMessageParser.isSingleLineCommitMessage(commitMessage)) {
             return new ValidationResult(commitMessage);
         }
 
@@ -49,7 +61,7 @@ module.exports = class HasNewLineBetweenSummaryAndDescriptionRule {
      * @private
      */
     _hasNewLineBetweenSummaryAndDescription (commitMessage) {
-        const lines = CommitMessageParser.getLines(commitMessage);
+        const lines = this._commitMessageParser.getLines(commitMessage);
         const secondLine = lines[1];
 
         // The second line could either be empty, or contain a single new-line character

--- a/lib/rules/has-new-line-between-summary-and-description-rule.js
+++ b/lib/rules/has-new-line-between-summary-and-description-rule.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const CommitMessageParser = require('../commit-message-parser');
+const ValidationResult = require('../validation-result');
+
+module.exports = class HasNewLineBetweenSummaryAndDescriptionRule {
+
+    constructor () {
+        this.type = 'NO_NEW_LINE_AFTER_FIRST_LINE';
+    }
+
+    /**
+     * Check that there is a new-line between the commit summary and description.
+     *
+     * Single line commit messages will just be considered valid.
+     *
+     * @param {string} commitMessage
+     */
+    validate (commitMessage) {
+        // For single-line commit messages, just consider them valid as testing for a new-line after the summary
+        // just doesn't make any sense.
+        if (CommitMessageParser.isSingleLineCommitMessage(commitMessage)) {
+            return new ValidationResult(commitMessage);
+        }
+
+        // If there's no new line between summary and description, then return a validation result with an
+        // appropriate error
+        if (!this._hasNewLineBetweenSummaryAndDescription(commitMessage)) {
+            return new ValidationResult(commitMessage, [this.type]);
+        }
+
+        return new ValidationResult(commitMessage);
+    }
+
+    /**
+     * Check if a multi-line commit message has a new line between the first and third lines.
+     * e.g.
+     *
+     *  """
+     *  [J#PROJ-123][BUG] Fix some bug
+     *
+     *  This fixes a bug introduced in the previous sprint.
+     *  """
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {boolean}
+     *
+     * @private
+     */
+    _hasNewLineBetweenSummaryAndDescription (commitMessage) {
+        const lines = CommitMessageParser.getLines(commitMessage);
+        const secondLine = lines[1];
+
+        // The second line could either be empty, or contain a single new-line character
+        return secondLine === '' || secondLine.trim() === '\n';
+    }
+};

--- a/lib/rules/has-valid-commit-type-rule.js
+++ b/lib/rules/has-valid-commit-type-rule.js
@@ -1,12 +1,24 @@
 'use strict';
 
-const CommitMessageParser = require('../commit-message-parser');
 const ValidationResult = require('../validation-result');
 
 module.exports = class HasValidCommitTypeRule {
 
-    constructor () {
+    /**
+     * @param {CommitMessageParser} commitMessageParser
+     */
+    constructor (commitMessageParser) {
+
+        /**
+         * @type {string}
+         */
         this.type = 'MISSING_OR_INVALID_COMMIT_TYPE';
+
+        /**
+         * @type {CommitMessageParser}
+         * @private
+         */
+        this._commitMessageParser = commitMessageParser;
     }
 
     /**
@@ -17,7 +29,7 @@ module.exports = class HasValidCommitTypeRule {
      * @returns {ValidationResult}
      */
     validate (commitMessage) {
-        const commitType = CommitMessageParser.getCommitType(commitMessage);
+        const commitType = this._commitMessageParser.getCommitType(commitMessage);
 
         if (commitType) {
             return new ValidationResult(commitMessage);

--- a/lib/rules/has-valid-commit-type-rule.js
+++ b/lib/rules/has-valid-commit-type-rule.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const CommitMessageParser = require('../commit-message-parser');
+const ValidationResult = require('../validation-result');
+
+module.exports = class HasValidCommitTypeRule {
+
+    constructor () {
+        this.type = 'MISSING_OR_INVALID_COMMIT_TYPE';
+    }
+
+    /**
+     * Check that a commit message has a valid commit type (e.g. BUG, FEATURE, etc.).
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {ValidationResult}
+     */
+    validate (commitMessage) {
+        const commitType = CommitMessageParser.getCommitType(commitMessage);
+
+        if (commitType) {
+            return new ValidationResult(commitMessage);
+        }
+
+        return new ValidationResult(commitMessage, [this.type]);
+    }
+};

--- a/lib/rules/valid-summary-rule.js
+++ b/lib/rules/valid-summary-rule.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// TODO: This rule should be replaced with more granular rules.
+
+const COMMIT_TYPES = require('../commit-types').COMMIT_TYPES;
+const CommitMessageParser = require('../commit-message-parser');
+const ValidationResult = require('../validation-result');
+
+const REGEXS = {
+    // Ticket number, commit type, and message
+    // e.g. "[J#PROJ-123][BUG] A short message"
+    ticketNumberWithCommitTypeAndMessage: new RegExp(
+        `^\\[[A-Z]#[A-Za-z0-9]+\-\\d+\\]\\[(${COMMIT_TYPES.join('|')})\\] .+$`
+    ),
+
+    // Commit type and message, but without the ticket number
+    // e.g. "[BUG] Fix issue"
+    noTicketNumberWithCommitTypeAndMessage: new RegExp(
+        `^\\[(${COMMIT_TYPES.join('|')})\\] .+$`
+    )
+};
+
+module.exports = class ValidSummaryRule {
+
+    constructor () {
+        this.type = 'FIRST_LINE_INVALID_FORMAT';
+    }
+
+    /**
+     * Check that the first-line of the commit message (the summary) is in a valid format.
+     *
+     * @param {string} commitMessage
+     *
+     * @returns {ValidationResult}
+     */
+    validate (commitMessage) {
+        const summary = CommitMessageParser.getSummary(commitMessage);
+
+        // We allow commit messages that either contain:
+        // - Ticket type, ticket number, commit type, and commit message, or:
+        // - Commit type, and commit message
+
+        const isValid = Boolean(
+            REGEXS.ticketNumberWithCommitTypeAndMessage.test(summary) ||
+            REGEXS.noTicketNumberWithCommitTypeAndMessage.test(summary)
+        );
+
+        if (isValid) {
+            return new ValidationResult(commitMessage);
+        }
+
+        return new ValidationResult(commitMessage, [this.type]);
+    }
+};

--- a/lib/rules/valid-summary-rule.js
+++ b/lib/rules/valid-summary-rule.js
@@ -3,7 +3,6 @@
 // TODO: This rule should be replaced with more granular rules.
 
 const COMMIT_TYPES = require('../commit-types').COMMIT_TYPES;
-const CommitMessageParser = require('../commit-message-parser');
 const ValidationResult = require('../validation-result');
 
 const REGEXS = {
@@ -22,8 +21,21 @@ const REGEXS = {
 
 module.exports = class ValidSummaryRule {
 
-    constructor () {
+    /**
+     * @param {CommitMessageParser} commitMessageParser
+     */
+    constructor (commitMessageParser) {
+
+        /**
+         * @type {string}
+         */
         this.type = 'FIRST_LINE_INVALID_FORMAT';
+
+        /**
+         * @type {CommitMessageParser}
+         * @private
+         */
+        this._commitMessageParser = commitMessageParser;
     }
 
     /**
@@ -34,7 +46,7 @@ module.exports = class ValidSummaryRule {
      * @returns {ValidationResult}
      */
     validate (commitMessage) {
-        const summary = CommitMessageParser.getSummary(commitMessage);
+        const summary = this._commitMessageParser.getSummary(commitMessage);
 
         // We allow commit messages that either contain:
         // - Ticket type, ticket number, commit type, and commit message, or:

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -2,35 +2,26 @@
 
 const ValidationResult = require('./validation-result');
 const CommitMessageParser = require('./commit-message-parser');
-const FAILURE_REASONS = require('./failure-reasons').FAILURE_REASONS;
-const COMMIT_TYPES = require('./commit-types').COMMIT_TYPES;
-
-const REGEXS = {
-    // Ticket number, commit type, and message
-    // e.g. "[J#PROJ-123][BUG] A short message"
-    ticketNumberWithCommitTypeAndMessage: new RegExp(
-        `^\\[[A-Z]#[A-Za-z0-9]+\-\\d+\\]\\[(${COMMIT_TYPES.join('|')})\\] .+$`
-    ),
-
-    // Commit type and message, but without the ticket number
-    // e.g. "[BUG] Fix issue"
-    noTicketNumberWithCommitTypeAndMessage: new RegExp(
-        `^\\[(${COMMIT_TYPES.join('|')})\\] .+$`
-    )
-};
 
 module.exports = class Validator {
 
     /**
      * @param {GitHelper} gitHelper
+     * @param {Array<{validate: ValidationResult}>} rules
      */
-    constructor (gitHelper) {
+    constructor (gitHelper, rules) {
 
         /**
          * @type {GitHelper}
          * @private
          */
         this._gitHelper = gitHelper;
+
+        /**
+         * @type {Array<{validate: ValidationResult}>}
+         * @private
+         */
+        this._rules = rules || [];
     }
 
     /**
@@ -53,11 +44,23 @@ module.exports = class Validator {
      * @returns {ValidationResult}
      */
     validateCommitMessage (commitMessage) {
-        if (CommitMessageParser.isSingleLineCommitMessage(commitMessage)) {
-            return this._validateSingleLineCommitMessage(commitMessage);
-        } else {
-            return this._validateMultiLineCommitMessage(commitMessage);
+        // If this is a merge commit, just consider it valid.
+        // Otherwise, run the commit message through all configured rules.
+        if (CommitMessageParser.isMergeCommit(commitMessage)) {
+            return new ValidationResult(commitMessage);
         }
+
+        let validationFailureReasons = [];
+
+        for (const rule of this._rules) {
+            const validationResult = rule.validate(commitMessage);
+
+            if (!validationResult.isValid) {
+                validationFailureReasons = validationFailureReasons.concat(validationResult.failures);
+            }
+        }
+
+        return new ValidationResult(commitMessage, validationFailureReasons);
     }
 
     /**
@@ -128,98 +131,5 @@ module.exports = class Validator {
      */
     isValidCommitMessage (commitMessage) {
         return this.validateCommitMessage(commitMessage).isValid === true;
-    }
-
-    /**
-     * Check if a single-line commit message is valid.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {ValidationResult}
-     *
-     * @private
-     */
-    _validateSingleLineCommitMessage (commitMessage) {
-        const failures = [];
-
-        // If the commit is a merge commit, don't do any further validation and just exit early
-        if (CommitMessageParser.isMergeCommit(commitMessage)) {
-            return new ValidationResult(commitMessage);
-        }
-
-        if (!this._isFirstLineValid(commitMessage)) {
-            failures.push(FAILURE_REASONS.firstLineInvalidFormat);
-        }
-
-        if (!CommitMessageParser.getCommitType(commitMessage)) {
-            failures.push(FAILURE_REASONS.missingOrInvalidCommitType);
-        }
-
-        return new ValidationResult(commitMessage, failures);
-    }
-
-    /**
-     * Check if a multi-line commit message is valid.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {ValidationResult}
-     *
-     * @private
-     */
-    _validateMultiLineCommitMessage (commitMessage) {
-        const result = this._validateSingleLineCommitMessage(commitMessage);
-
-        if (!this._hasNewLineBetweenMessageAndDescription(commitMessage)) {
-            result.failures.push(FAILURE_REASONS.noNewLineAfterFirstLine);
-        }
-
-        return result;
-    }
-
-    /**
-     * Check that the first line of a commit message is in the correct format.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {boolean}
-     *
-     * @private
-     */
-    _isFirstLineValid (commitMessage) {
-        const summary = CommitMessageParser.getSummary(commitMessage);
-
-        // We allow commit messages that either contain:
-        // - Ticket type, ticket number, commit type, and commit message, or:
-        // - Commit type, and commit message
-
-        return Boolean(
-            REGEXS.ticketNumberWithCommitTypeAndMessage.test(summary) ||
-            REGEXS.noTicketNumberWithCommitTypeAndMessage.test(summary)
-        );
-    }
-
-    /**
-     * Check if a multi-line commit message has a new line between the first and third lines.
-     * e.g.
-     *
-     *  """
-     *  [J#PROJ-123][BUG] Fix some bug
-     *
-     *  This fixes a bug introduced in the previous sprint.
-     *  """
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {boolean}
-     *
-     * @private
-     */
-    _hasNewLineBetweenMessageAndDescription (commitMessage) {
-        const lines = CommitMessageParser.getLines(commitMessage);
-        const secondLine = lines[1];
-
-        // The second line could either be empty, or contain a single new-line character
-        return secondLine === '' || secondLine.trim() === '\n';
     }
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,21 +1,27 @@
 'use strict';
 
 const ValidationResult = require('./validation-result');
-const CommitMessageParser = require('./commit-message-parser');
 
 module.exports = class Validator {
 
     /**
      * @param {GitHelper} gitHelper
+     * @param {CommitMessageParser} commitMessageParser
      * @param {Array<{validate: ValidationResult}>} rules
      */
-    constructor (gitHelper, rules) {
+    constructor (gitHelper, commitMessageParser, rules) {
 
         /**
          * @type {GitHelper}
          * @private
          */
         this._gitHelper = gitHelper;
+
+        /**
+         * @type {CommitMessageParser}
+         * @private
+         */
+        this._commitMessageParser = commitMessageParser;
 
         /**
          * @type {Array<{validate: ValidationResult}>}
@@ -46,7 +52,7 @@ module.exports = class Validator {
     validateCommitMessage (commitMessage) {
         // If this is a merge commit, just consider it valid.
         // Otherwise, run the commit message through all configured rules.
-        if (CommitMessageParser.isMergeCommit(commitMessage)) {
+        if (this._commitMessageParser.isMergeCommit(commitMessage)) {
             return new ValidationResult(commitMessage);
         }
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ValidationResult = require('./validation-result');
+const CommitMessageParser = require('./commit-message-parser');
 const FAILURE_REASONS = require('./failure-reasons').FAILURE_REASONS;
 const COMMIT_TYPES = require('./commit-types').COMMIT_TYPES;
 
@@ -15,16 +16,6 @@ const REGEXS = {
     // e.g. "[BUG] Fix issue"
     noTicketNumberWithCommitTypeAndMessage: new RegExp(
         `^\\[(${COMMIT_TYPES.join('|')})\\] .+$`
-    ),
-
-    mergeCommit: new RegExp(`^Merge .+$`),
-
-    // Get the commit type from a commit message,
-    // e.g. "[J#PROJ-123][BUG] Fixes some bug"
-    // or "[BUG] Fixes some bug"
-    // would match "BUG".
-    getCommitType: new RegExp(
-        `^(\\[.#[A-Z0-9\-]+\\])?\\[(${COMMIT_TYPES.join('|')})\\]`
     )
 };
 
@@ -62,7 +53,7 @@ module.exports = class Validator {
      * @returns {ValidationResult}
      */
     validateCommitMessage (commitMessage) {
-        if (this._isSingleLineCommitMessage(commitMessage)) {
+        if (CommitMessageParser.isSingleLineCommitMessage(commitMessage)) {
             return this._validateSingleLineCommitMessage(commitMessage);
         } else {
             return this._validateMultiLineCommitMessage(commitMessage);
@@ -152,7 +143,7 @@ module.exports = class Validator {
         const failures = [];
 
         // If the commit is a merge commit, don't do any further validation and just exit early
-        if (this._isMergeCommit(commitMessage)) {
+        if (CommitMessageParser.isMergeCommit(commitMessage)) {
             return new ValidationResult(commitMessage);
         }
 
@@ -160,7 +151,7 @@ module.exports = class Validator {
             failures.push(FAILURE_REASONS.firstLineInvalidFormat);
         }
 
-        if (!this._getCommitType(commitMessage)) {
+        if (!CommitMessageParser.getCommitType(commitMessage)) {
             failures.push(FAILURE_REASONS.missingOrInvalidCommitType);
         }
 
@@ -187,29 +178,6 @@ module.exports = class Validator {
     }
 
     /**
-     * Get the commit type from a commit message.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {string|undefined} The commit type (e.g. "BUG"), or undefined if not found
-     *
-     * @private
-     */
-    _getCommitType (commitMessage) {
-        const lines = this._getLines(commitMessage);
-        const firstLine = lines[0];
-
-        const matches = firstLine.match(REGEXS.getCommitType);
-        const commitTypeIndex = 2;
-
-        if (!matches) {
-            return undefined;
-        }
-
-        return matches[commitTypeIndex];
-    }
-
-    /**
      * Check that the first line of a commit message is in the correct format.
      *
      * @param {string} commitMessage
@@ -219,16 +187,15 @@ module.exports = class Validator {
      * @private
      */
     _isFirstLineValid (commitMessage) {
-        const lines = this._getLines(commitMessage);
-        const firstLine = lines[0];
+        const summary = CommitMessageParser.getSummary(commitMessage);
 
         // We allow commit messages that either contain:
         // - Ticket type, ticket number, commit type, and commit message, or:
         // - Commit type, and commit message
 
         return Boolean(
-            REGEXS.ticketNumberWithCommitTypeAndMessage.test(firstLine) ||
-            REGEXS.noTicketNumberWithCommitTypeAndMessage.test(firstLine)
+            REGEXS.ticketNumberWithCommitTypeAndMessage.test(summary) ||
+            REGEXS.noTicketNumberWithCommitTypeAndMessage.test(summary)
         );
     }
 
@@ -249,51 +216,10 @@ module.exports = class Validator {
      * @private
      */
     _hasNewLineBetweenMessageAndDescription (commitMessage) {
-        const lines = this._getLines(commitMessage);
+        const lines = CommitMessageParser.getLines(commitMessage);
         const secondLine = lines[1];
 
         // The second line could either be empty, or contain a single new-line character
         return secondLine === '' || secondLine.trim() === '\n';
-    }
-
-    /**
-     * Check if a commit is a merge commit.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {boolean}
-     *
-     * @private
-     */
-    _isMergeCommit (commitMessage) {
-        const firstLine = this._getLines(commitMessage)[0];
-
-        return REGEXS.mergeCommit.test(firstLine);
-    }
-
-    /**
-     * Check if a commit message is a single-line, i.e. there is no description.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {boolean}
-     *
-     * @private
-     */
-    _isSingleLineCommitMessage (commitMessage) {
-        const lines = this._getLines(commitMessage);
-
-        return lines.length === 1;
-    }
-
-    /**
-     * Return the lines of a commit message as an array.
-     *
-     * @param {string} commitMessage
-     *
-     * @returns {Array<string>}
-     */
-    _getLines (commitMessage) {
-        return commitMessage.split('\n');
     }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run unit-tests && npm run lint",
-    "unit-tests": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec test/end-to-end/*.js test/unit/**/*.js",
+    "unit-tests": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec test/end-to-end/*.js test/unit/lib/*.js test/unit/lib/**/*.js",
     "lint": "eslint *.js lib/**/*.js reporter/**/*.js tools/**/*.js"
   },
   "bin": {

--- a/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
+++ b/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+const HasNewLineBetweenSummaryAndDescriptionRule = require(
+    '../../../../lib/rules/has-new-line-between-summary-and-description-rule'
+);
+
+describe('Rules: HasNewLineBetweenSummaryAndDescriptionRule', () => {
+    let hasNewLineBetweenSummaryAndDescriptionRule;
+
+    beforeEach(() => {
+        hasNewLineBetweenSummaryAndDescriptionRule = new HasNewLineBetweenSummaryAndDescriptionRule();
+    });
+
+    describe('single-line commit messages', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = 'Fix issue with foo';
+            validationResult = hasNewLineBetweenSummaryAndDescriptionRule.validate(commitMessage);
+        });
+
+        it('should be marked as valid', () => {
+            expect(validationResult.isValid).to.be.true;
+        });
+
+        it('should not have any failures', () => {
+            expect(validationResult.failures).to.be.empty;
+        });
+    });
+
+    describe('multi-line commit message without empty new-line between summary and description', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = 'Summary\nDescription';
+            validationResult = hasNewLineBetweenSummaryAndDescriptionRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(hasNewLineBetweenSummaryAndDescriptionRule.type);
+        });
+    });
+
+    describe('multi-line commit message with an empty new-line between summary and description', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = 'Summary\n\nDescription';
+            validationResult = hasNewLineBetweenSummaryAndDescriptionRule.validate(commitMessage);
+        });
+
+        it('should be marked as valid', () => {
+            expect(validationResult.isValid).to.be.true;
+        });
+
+        it('should not have any failures', () => {
+            expect(validationResult.failures).to.be.empty;
+        });
+    });
+});

--- a/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
+++ b/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
@@ -7,6 +7,7 @@ chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
 
+const CommitMessageParser = require('../../../../lib/commit-message-parser');
 const HasNewLineBetweenSummaryAndDescriptionRule = require(
     '../../../../lib/rules/has-new-line-between-summary-and-description-rule'
 );
@@ -15,7 +16,9 @@ describe('Rules: HasNewLineBetweenSummaryAndDescriptionRule', () => {
     let hasNewLineBetweenSummaryAndDescriptionRule;
 
     beforeEach(() => {
-        hasNewLineBetweenSummaryAndDescriptionRule = new HasNewLineBetweenSummaryAndDescriptionRule();
+        hasNewLineBetweenSummaryAndDescriptionRule = new HasNewLineBetweenSummaryAndDescriptionRule(
+            new CommitMessageParser()
+        );
     });
 
     describe('single-line commit messages', () => {

--- a/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
+++ b/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
@@ -8,13 +8,14 @@ chai.use(require('sinon-chai'));
 const expect = chai.expect;
 
 const COMMIT_TYPES = require('../../../../lib/commit-types').COMMIT_TYPES;
+const CommitMessageParser = require('../../../../lib/commit-message-parser');
 const HasValidCommitTypeRule = require('../../../../lib/rules/has-valid-commit-type-rule');
 
 describe('Rules: HasValidCommitTypeRule', () => {
     let hasValidCommitTypeRule;
 
     beforeEach(() => {
-        hasValidCommitTypeRule = new HasValidCommitTypeRule();
+        hasValidCommitTypeRule = new HasValidCommitTypeRule(new CommitMessageParser());
     });
 
     describe('a commit message without type', () => {

--- a/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
+++ b/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+const COMMIT_TYPES = require('../../../../lib/commit-types').COMMIT_TYPES;
+const HasValidCommitTypeRule = require('../../../../lib/rules/has-valid-commit-type-rule');
+
+describe('Rules: HasValidCommitTypeRule', () => {
+    let hasValidCommitTypeRule;
+
+    beforeEach(() => {
+        hasValidCommitTypeRule = new HasValidCommitTypeRule();
+    });
+
+    describe('a commit message without type', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = 'Some commit message';
+            validationResult = hasValidCommitTypeRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(hasValidCommitTypeRule.type);
+        });
+    });
+
+    describe('a commit message with an invalid type', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = '[FOO] Some commit message';
+            validationResult = hasValidCommitTypeRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(hasValidCommitTypeRule.type);
+        });
+    });
+
+    describe('commit messages with valid types', () => {
+        for (const commitType of COMMIT_TYPES) {
+            describe(`commit message: "[${commitType}] Fix issue with foo"`, () => {
+                let commitMessage;
+                let validationResult;
+
+                beforeEach(() => {
+                    commitMessage = `[${commitType}] Fix issue with foo`;
+                    validationResult = hasValidCommitTypeRule.validate(commitMessage);
+                });
+
+                it('should be marked as valid', () => {
+                    expect(validationResult.isValid).to.be.true;
+                });
+
+                it('should not have any failures', () => {
+                    expect(validationResult.failures).to.be.empty;
+                });
+            });
+
+            describe(`commit message: "[J#PROJ-987][${commitType}] Fix issue with foo"`, () => {
+                let commitMessage;
+                let validationResult;
+
+                beforeEach(() => {
+                    commitMessage = `[${commitType}] Fix issue with foo`;
+                    validationResult = hasValidCommitTypeRule.validate(commitMessage);
+                });
+
+                it('should be marked as valid', () => {
+                    expect(validationResult.isValid).to.be.true;
+                });
+
+                it('should not have any failures', () => {
+                    expect(validationResult.failures).to.be.empty;
+                });
+            });
+        }
+    });
+});

--- a/test/unit/lib/rules/valid-summary-rule.spec.js
+++ b/test/unit/lib/rules/valid-summary-rule.spec.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.use(require('sinon-chai'));
+
+const expect = chai.expect;
+
+const ValidSummaryRule = require('../../../../lib/rules/valid-summary-rule');
+
+describe('Rules: ValidSummaryRule', () => {
+    let validSummaryRule;
+
+    beforeEach(() => {
+        validSummaryRule = new ValidSummaryRule();
+    });
+
+    describe('commit message: "Some commit message"', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = 'Some commit message';
+            validationResult = validSummaryRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(validSummaryRule.type);
+        });
+    });
+
+    describe('commit message: "[BUG] Fix issue with foo"', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = '[BUG] Fix issue with foo';
+            validationResult = validSummaryRule.validate(commitMessage);
+        });
+
+        it('should be marked as valid', () => {
+            expect(validationResult.isValid).to.be.true;
+        });
+
+        it('should not have any failures', () => {
+            expect(validationResult.failures).to.be.empty;
+        });
+    });
+
+    describe('commit message: "[J#PROJ-123][BUG] Fix issue with foo"', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = '[J#PROJ-123][BUG] Fix issue with foo';
+            validationResult = validSummaryRule.validate(commitMessage);
+        });
+
+        it('should be marked as valid', () => {
+            expect(validationResult.isValid).to.be.true;
+        });
+
+        it('should not have any failures', () => {
+            expect(validationResult.failures).to.be.empty;
+        });
+    });
+
+    describe('commit message: "[J#PROJ-123][BUG]Fix issue with foo"', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = '[J#PROJ-123][BUG]Fix issue with foo';
+            validationResult = validSummaryRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(validSummaryRule.type);
+        });
+    });
+
+    describe('commit message: "[J#PROJ-123] Fix issue with foo"', () => {
+        let commitMessage;
+        let validationResult;
+
+        beforeEach(() => {
+            commitMessage = '[J#PROJ-123] Fix issue with foo';
+            validationResult = validSummaryRule.validate(commitMessage);
+        });
+
+        it('should be marked as invalid', () => {
+            expect(validationResult.isValid).to.be.false;
+        });
+
+        it('should only have 1 failure reason', () => {
+            expect(validationResult.failures.length).to.equal(1);
+        });
+
+        it('should have the correct failure reason', () => {
+            expect(validationResult.failures[0]).to.equal(validSummaryRule.type);
+        });
+    });
+});

--- a/test/unit/lib/rules/valid-summary-rule.spec.js
+++ b/test/unit/lib/rules/valid-summary-rule.spec.js
@@ -7,13 +7,14 @@ chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
 
+const CommitMessageParser = require('../../../../lib/commit-message-parser');
 const ValidSummaryRule = require('../../../../lib/rules/valid-summary-rule');
 
 describe('Rules: ValidSummaryRule', () => {
     let validSummaryRule;
 
     beforeEach(() => {
-        validSummaryRule = new ValidSummaryRule();
+        validSummaryRule = new ValidSummaryRule(new CommitMessageParser());
     });
 
     describe('commit message: "Some commit message"', () => {

--- a/test/unit/lib/validator.spec.js
+++ b/test/unit/lib/validator.spec.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 
+const CommitMessageParser = require('../../../lib/commit-message-parser');
 const Validator = require('../../../lib/validator');
 const ValidationResult = require('../../../lib/validation-result');
 
@@ -25,7 +26,7 @@ describe('validator', () => {
     describe('validating a commit message and checking for errors', () => {
         it('should correctly identify a valid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             const validationResult = validator.validateCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -34,7 +35,7 @@ describe('validator', () => {
 
         it('should return a validation result with no errors when the commit message is valid', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             const validationResult = validator.validateCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -44,7 +45,7 @@ describe('validator', () => {
 
         it('should correctly identify an invalid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysInvalidRule]);
 
             const validationResult = validator.validateCommitMessage('An invalid commit message');
 
@@ -53,7 +54,7 @@ describe('validator', () => {
 
         it('should return a validation result with errors when the commit message is invalid', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysInvalidRule]);
 
             const validationResult = validator.validateCommitMessage('An invalid commit message');
 
@@ -64,7 +65,7 @@ describe('validator', () => {
     describe('validating a set of commit messages and checking for errors', () => {
         it('should return an array with the correct number of validation results', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             const validationResults = validator.validateCommitMessages([
                 'An invalid commit message',
@@ -87,7 +88,7 @@ describe('validator', () => {
             };
 
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [fakeRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [fakeRule]);
 
             const validationResults = validator.validateCommitMessages([
                 'A valid commit message',
@@ -107,7 +108,7 @@ describe('validator', () => {
     describe('checking if a commit message is valid', () => {
         it('should correctly identify a valid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             const isValid = validator.isValidCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -116,7 +117,7 @@ describe('validator', () => {
 
         it('should correctly identify an invalid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysInvalidRule]);
 
             const isValid = validator.isValidCommitMessage('An invalid commit message');
 
@@ -132,7 +133,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -151,7 +152,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -170,7 +171,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysInvalidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -189,7 +190,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysInvalidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -210,7 +211,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
 
             validator.validateCommitMessagesFromSHAs([
                 '0d4d577f797a76b63421afc68b904a16ac817315',
@@ -237,7 +238,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper, [alwaysValidRule]);
+            const validator = new Validator(gitHelper, new CommitMessageParser(), [alwaysValidRule]);
             const range = '0d4d577f797a76b63421afc68b904a16ac817315...0d4d577f797a76b63421afc68b904a16ac817315';
 
             validator.validateCommitMessagesFromSHARange(range)

--- a/test/unit/lib/validator.spec.js
+++ b/test/unit/lib/validator.spec.js
@@ -5,12 +5,27 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const Validator = require('../../../lib/validator');
+const ValidationResult = require('../../../lib/validation-result');
 
 describe('validator', () => {
+    let alwaysValidRule;
+    let alwaysInvalidRule;
+
+    beforeEach(() => {
+        // A mock rule we can use for testing when the validator handled a valid message
+        alwaysValidRule = {
+            validate: commitMessage => new ValidationResult(commitMessage)
+        };
+
+        alwaysInvalidRule = {
+            validate: commitMessage => new ValidationResult(commitMessage, ['SOME_FAILURE_REASON'])
+        };
+    });
+
     describe('validating a commit message and checking for errors', () => {
         it('should correctly identify a valid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             const validationResult = validator.validateCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -19,7 +34,7 @@ describe('validator', () => {
 
         it('should return a validation result with no errors when the commit message is valid', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             const validationResult = validator.validateCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -29,7 +44,7 @@ describe('validator', () => {
 
         it('should correctly identify an invalid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
 
             const validationResult = validator.validateCommitMessage('An invalid commit message');
 
@@ -38,7 +53,7 @@ describe('validator', () => {
 
         it('should return a validation result with errors when the commit message is invalid', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
 
             const validationResult = validator.validateCommitMessage('An invalid commit message');
 
@@ -49,7 +64,7 @@ describe('validator', () => {
     describe('validating a set of commit messages and checking for errors', () => {
         it('should return an array with the correct number of validation results', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             const validationResults = validator.validateCommitMessages([
                 'An invalid commit message',
@@ -60,28 +75,39 @@ describe('validator', () => {
         });
 
         it('should correctly identify valid and invalid commit messages', () => {
+            const fakeRule = {
+                validate: commitMessage => {
+                    // A fake rule that will consider a message valid so long as it doesn't contain the word "invalid"
+                    if (commitMessage.indexOf('invalid') !== -1) {
+                        return new ValidationResult(commitMessage, ['SOME_ERROR']);
+                    }
+
+                    return new ValidationResult(commitMessage);
+                }
+            };
+
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [fakeRule]);
 
             const validationResults = validator.validateCommitMessages([
-                'An invalid commit message',
-                '[J#PROJ-123][BUG] Fix issue with foo'
+                'A valid commit message',
+                'An invalid commit message'
             ]);
 
-            // Check the result that should be invalid
-            expect(validationResults[0].isValid).to.be.false;
-            expect(validationResults[0].failures).not.to.be.empty;
-
             // Check the result that should be valid
-            expect(validationResults[1].isValid).to.be.true;
-            expect(validationResults[1].failures).to.be.empty;
+            expect(validationResults[0].isValid).to.be.true;
+            expect(validationResults[0].failures).to.be.empty;
+
+            // Check the result that should be invalid
+            expect(validationResults[1].isValid).to.be.false;
+            expect(validationResults[1].failures).not.to.be.empty;
         });
     });
 
     describe('checking if a commit message is valid', () => {
         it('should correctly identify a valid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             const isValid = validator.isValidCommitMessage('[J#PROJ-123][BUG] Fix issue with foo');
 
@@ -90,7 +116,7 @@ describe('validator', () => {
 
         it('should correctly identify an invalid commit message', () => {
             const gitHelper = {};
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
 
             const isValid = validator.isValidCommitMessage('An invalid commit message');
 
@@ -106,7 +132,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -125,7 +151,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -144,7 +170,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -163,7 +189,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysInvalidRule]);
 
             validator.validateCommitMessageFromSHA('0d4d577f797a76b63421afc68b904a16ac817315')
                 .then(validationResult => {
@@ -184,7 +210,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
 
             validator.validateCommitMessagesFromSHAs([
                 '0d4d577f797a76b63421afc68b904a16ac817315',
@@ -211,7 +237,7 @@ describe('validator', () => {
                 })
             };
 
-            const validator = new Validator(gitHelper);
+            const validator = new Validator(gitHelper, [alwaysValidRule]);
             const range = '0d4d577f797a76b63421afc68b904a16ac817315...0d4d577f797a76b63421afc68b904a16ac817315';
 
             validator.validateCommitMessagesFromSHARange(range)


### PR DESCRIPTION
## [REFACTOR] Move commit parsing into own class
A lot of commit message parsing was being handled as private methods of `Validator`. Basic parsing has now been moved to `CommitMessageParser` in order to manage separation of concerns, and to allow for validation to be moved out into separate rules (all of which will need to parse commit messages).

## [REFACTOR] Move validation logic into rules
Currently all validation logic was intwined within the `Validator` class.

That worked fine, but it has some downsides:

* difficult to test individual parts of the validation
* difficult to extend this with additional validation rules, without digging into underlying `Validation` class

This commit moves all validation logic into individual Rule classes (e.g. `HasValidCommitTypeRule`). This means that specific validation rules can be tested in isolation, and it becomes very easy to add new rules (or modify existing ones) in the future without having to work around everything else that's going on.

The `Validator` class is now only concerned with testing a commit message against a provided set of rules.

Unit tests for the `Validator` now use mocked rules, making it easier to test the output when we know a rule will pass or fail a message (i.e. it's no longer black box testing). We still have a set of end-to-end tests that use the full set of rules. (The library exposes an instance of `Validator` configured with a set of rules; the end-to-end tests run against this).