### PR TITLE
[SETUP] Add Coveralls.io reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ cache:
 script:
     - npm test
     - node ./tools/travis-commit-message-checker.js
+
+after_success:
+    - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Commit message checker
 
+[![Coverage Status](https://coveralls.io/repos/github/boxuk/commit-message-checker/badge.svg?branch=master)](https://coveralls.io/github/boxuk/commit-message-checker?branch=master)
+
 * [Overview](#overview)
   * [Valid commit types](#valid-commit-types)
   * [Failure reasons](#failure-reasons)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Commit message checker
 
 [![Coverage Status](https://coveralls.io/repos/github/boxuk/commit-message-checker/badge.svg?branch=master)](https://coveralls.io/github/boxuk/commit-message-checker?branch=master)
+[![Build Status](https://travis-ci.com/boxuk/commit-message-checker.svg?token=PXYWMazXQJ8xQq72h6EJ&branch=master)](https://travis-ci.com/boxuk/commit-message-checker)
 
 * [Overview](#overview)
   * [Valid commit types](#valid-commit-types)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run unit-tests && npm run lint",
     "unit-tests": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec test/end-to-end/*.js test/unit/**/*.js",
-    "lint": "eslint *.js lib/**/*.js reporter/**/*.js tools/**/*.js"
+    "lint": "eslint *.js lib/**/*.js reporter/**/*.js tools/**/*.js",
+    "coveralls": "cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js"
   },
   "bin": {
     "travis-commit-message-checker": "./tools/travis-commit-message-checker.js",
@@ -16,6 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",
+    "coveralls": "^2.11.15",
     "eslint": "^3.9.1",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.3.0",


### PR DESCRIPTION
Post coverage data to Coveralls.io on a successful Travis build. No needs to do this from Appveyor, so long as one of the builds posts the data.