### PR TITLE
[SETUP] Add CodeClimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+engines:
+  eslint:
+    enabled: true
+    channel: 'eslint-3'
+    config:
+        config: ./eslintrc.yml


### PR DESCRIPTION
CodeClimate runs eslint, but by default was running eslint v1. We use v3 (the latest) and so the config file was incompatible.

This commit adds a cofnig file to tell CodeClimate to use eslint v3.