### PR TITLE
[SETUP] Add CodeClimate paths to calculate GPA

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,11 @@ engines:
   eslint:
     enabled: true
     channel: 'eslint-3'
+
+ratings:
+  paths:
+    - '*.js'
+    - 'lib/**/*.js'
+    - 'reporter/**/*.js'
+    - 'test/**/*.js'
+    - 'tools/**/*.js'


### PR DESCRIPTION
I thought this was automatic, but it's not.

See: https://docs.codeclimate.com/docs/ratings

This commit specifies which files to calculate a rating for.