### PR TITLE
[FEATURE] Add git commit msg hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   * [As part of CI](#as-part-of-ci)
     * [Travis](#travis)
     * [Appveyor](#appveyor)
+  * [As a commit hook](#as-a-commit-hook)
   * [As a Node module](#as-a-node-module)
     * [Quick overview of basic usage](#quick-overview-of-basic-usage)
     * [API documentation](#api-documentation)
@@ -121,6 +122,32 @@ Registrations are not currently supported and will be addressed in J#PROJ-988.
 ```yml
 - cmd: node_modules/.bin/appveyor-commit-message-checker
 ```
+
+### As a commit hook
+
+A `commit-msg` hook is provided which you can setup to run in your development environment, to help catch invalid commit
+messages as they happen.
+
+This is intended to be setup in addition to, and definitely not instead of, checks that run [as part of CI](#as-part-of-ci).
+It's primary purpose is to shorten the feedback time between commiting something, and finding out that the commit
+message is invalid. The alternative being that you don't find out until it fails on CI, which could take a frustrating
+amount of time.
+
+To use the commit hook, copy or symlink the file to `.git/hooks/commit-msg` within your project. i.e. run:
+
+```bash
+ln -s -f ../../node_modules/.bin/commit-message-hook .git/hooks/commit-msg
+```
+
+After doing so, all commits you make will be validated.
+
+If any commit message fails, you'll be shown a failure report detailing the reason(s) why the message isn't valid.
+
+However, this **will not block the commit** from happening.
+We want to limit impact on developer workflow as much as possible, and so this will notify you that a commit message is
+invalid, but the onus will be on you to go back and correct it. We've made this decision so as not to prevent you
+making a series of quick commits as you work, with the intention of going back and fixing up / re-wording commits prior
+to pushing to your SCM.
 
 ### As a Node module
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "bin": {
     "travis-commit-message-checker": "./tools/travis-commit-message-checker.js",
-    "appveyor-commit-message-checker": "./tools/appveyor-commit-message-checker.js"
+    "appveyor-commit-message-checker": "./tools/appveyor-commit-message-checker.js",
+    "commit-message-hook": "./tools/commit-message-hook.js"
   },
   "author": "Box UK <https://www.boxuk.com>",
   "license": "MIT",

--- a/tools/commit-message-hook.js
+++ b/tools/commit-message-hook.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview
+ *
+ * A commit-msg hook that can be used for validating commit messages on the client-side.
+ *
+ * Note that if an invalid commit is detected then a report detailing the failures will be output, but the
+ * commit will not be blocked.
+ *
+ * We want to limit impact on developer workflow as little as possible, and so by displaying reasons why the message
+ * is invalid but also allowing the commit to happen, we put the onus on the developer to fix any failures prior to
+ * pushing the commit to SCM (and triggering a CI build where the invalid commit message should fail the build).
+ *
+ * Usage:
+ * ======
+ *
+ * Link this file to your git hooks directory within your repo.
+ *
+ * ln -s -f ../../node_modules/.bin/commit-message-hook .git/hooks/commit-msg
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+const lib = require('../lib');
+const reporter = require('../reporter').table;
+
+// The path to the temporary file containing the commit message will be passed in as the first argument.
+// process.argv will contain the following:
+//  - 0: Path to node executable
+//  - 1: Path to JS file being executed (this file)
+//  - 2: First argument, in this case the file path of the commit message
+const commitMessageFileLocation = process.argv[2];
+
+fs.readFile(commitMessageFileLocation, (error, data) => {
+    if (error) {
+        throw new Error(error);
+    }
+
+    const commitMessage = data.toString();
+    const validationResult = lib.validateCommitMessage(commitMessage);
+
+    if (!validationResult.isValid) {
+        // The commit message is invalid, so output report explaining why.
+        // We could also exit with a non-0 code here, which would block the commit.
+        reporter([validationResult]);
+    }
+});


### PR DESCRIPTION
Add a commit-msg hook to be used within Git on the client-side.

Closes #13 