### PR TITLE
[FORMAT] Remove unused deps from test files

### DIFF
--- a/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
+++ b/test/unit/lib/rules/has-new-line-between-summary-and-description-rule.spec.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const sinon = require('sinon');
-
-chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
 

--- a/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
+++ b/test/unit/lib/rules/has-valid-commit-type-rule.spec.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const sinon = require('sinon');
-
-chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
 

--- a/test/unit/lib/rules/valid-summary-rule.spec.js
+++ b/test/unit/lib/rules/valid-summary-rule.spec.js
@@ -1,9 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const sinon = require('sinon');
-
-chai.use(require('sinon-chai'));
 
 const expect = chai.expect;
 


### PR DESCRIPTION
Removes some unused dependencies and variables from test files. These were left over when the test file was copied and pasted from another file where they *were* used. Linting issue.